### PR TITLE
Add authorization framework

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,12 @@ gem 'kaminari'
 
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
-
-# Use Puma as the app server
-gem 'puma', '~> 3.11'
 # Use Pry for the console - solves some issues with arrow keys on Mac OSX
 gem 'pry-rails'
+# Use Puma as the app server
+gem 'puma', '~> 3.11'
+# Pundit for authorization
+gem 'pundit'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     puma (3.12.0)
+    pundit (2.0.1)
+      activesupport (>= 3.0.0)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -215,6 +217,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.11)
+  pundit
   rails (~> 5.2.2)
   rspec-rails
   simplecov

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,8 +1,22 @@
 module Api
   module V1
     class ApiController < ApplicationController
+      before_action :stub_current_user!
+
+      include Pundit
+      after_action :verify_authorized
 
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
+      rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+      # we have no concept of user identity yet, but Pundit requires a
+      # current_user method
+      def stub_current_user!
+        @current_user = nil
+      end
+      def current_user
+        @current_user
+      end
 
       def jsonapi_pagination(collection)
         {
@@ -21,8 +35,14 @@ module Api
         end
       end
 
-      def not_found(e)
-        render json: {error: e}, status: :not_found
+      def not_found(exception)
+        render json: {error: exception}, status: :not_found
+      end
+
+      def user_not_authorized(exception)
+        policy_name = exception.policy.class.to_s.underscore
+
+        render json: {error: exception}, status: :forbidden
       end
 
     end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,21 +1,28 @@
 module Api
   module V1
     class ApiController < ApplicationController
+
+      rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
       def jsonapi_pagination(collection)
         {
           first: helpers.first_page_link(collection),
           last: helpers.last_page_link(collection),
           prev: helpers.previous_page_link(collection),
           next: helpers.next_page_link(collection)
-        }
+        } if collection.respond_to?(:current_page)
       end
 
-      protected
+      private
 
       def respond_with(data)
         if request.format.json?
           render jsonapi: data
         end
+      end
+
+      def not_found(e)
+        render json: {error: e}, status: :not_found
       end
 
     end

--- a/app/controllers/api/v1/organisation_types_controller.rb
+++ b/app/controllers/api/v1/organisation_types_controller.rb
@@ -9,6 +9,11 @@ module Api
 
         respond_with @organisation_types
       end
+
+      def show
+        @organisation_type = OrganisationType.friendly.find(params[:id])
+        respond_with @organisation_type
+      end
     end
   end
 end

--- a/app/controllers/api/v1/organisation_types_controller.rb
+++ b/app/controllers/api/v1/organisation_types_controller.rb
@@ -6,12 +6,13 @@ module Api
           OrganisationType.all
             .order(helpers.to_activerecord_order_clause(params[:sort]))
         )
-
+        authorize @organisation_types
         respond_with @organisation_types
       end
 
       def show
         @organisation_type = OrganisationType.friendly.find(params[:id])
+        authorize @organisation_type
         respond_with @organisation_type
       end
     end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,50 @@
+# default policy - no-one can do anything
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/open_policy.rb
+++ b/app/policies/open_policy.rb
@@ -1,0 +1,22 @@
+# Anyone can do anything
+class OpenPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    true
+  end
+
+  def destroy?
+    true
+  end
+end

--- a/app/policies/organisation_type_policy.rb
+++ b/app/policies/organisation_type_policy.rb
@@ -1,3 +1,2 @@
 class OrganisationTypePolicy < OpenPolicy
-
 end

--- a/app/policies/organisation_type_policy.rb
+++ b/app/policies/organisation_type_policy.rb
@@ -1,0 +1,3 @@
+class OrganisationTypePolicy < OpenPolicy
+
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # custom config goes here
+  # config.debug_exception_response_format = :api
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe ApplicationPolicy do
+  let(:user) { nil }
+  let(:record) { nil }
+  subject do
+    described_class.new(user, record)
+  end
+
+  describe '#index?' do
+    it 'is false' do
+      expect(subject.index?).to eq(false)
+    end
+  end
+
+  describe '#show?' do
+    it 'is false' do
+      expect(subject.show?).to eq(false)
+    end
+  end
+
+  describe '#edit?' do
+    it 'is false' do
+      expect(subject.edit?).to eq(false)
+    end
+  end
+
+  describe '#update?' do
+    it 'is false' do
+      expect(subject.update?).to eq(false)
+    end
+  end
+
+  describe '#destroy?' do
+    it 'is false' do
+      expect(subject.destroy?).to eq(false)
+    end
+  end
+
+  describe '#new?' do
+    it 'is false' do
+      expect(subject.new?).to eq(false)
+    end
+  end
+
+  describe '#create?' do
+    it 'is false' do
+      expect(subject.create?).to eq(false)
+    end
+  end
+
+  describe ApplicationPolicy::Scope do
+    let(:scope) { double('scope', all: 'mock all') }
+    subject do
+      described_class.new(user, scope)
+    end
+    describe 'creating a new scope' do
+
+      it 'stores the given user' do
+        expect(subject.user).to eq(user)
+      end
+      it 'stores the given scope' do
+        expect(subject.scope).to eq(scope)
+      end
+    end
+
+    describe '.resolve' do
+      it 'returns scope.all' do
+        expect(subject.resolve).to eq('mock all')
+      end
+    end
+  end
+end

--- a/spec/policies/open_policy_spec.rb
+++ b/spec/policies/open_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe OpenPolicy do
+  let(:user) { nil }
+  let(:record) { nil }
+  subject do
+    described_class.new(user, record)
+  end
+
+  describe '#index?' do
+    it 'is true' do
+      expect(subject.index?).to eq(true)
+    end
+  end
+
+  describe '#show?' do
+    it 'is true' do
+      expect(subject.show?).to eq(true)
+    end
+  end
+
+  describe '#update?' do
+    it 'is true' do
+      expect(subject.update?).to eq(true)
+    end
+  end
+
+  describe '#destroy?' do
+    it 'is true' do
+      expect(subject.destroy?).to eq(true)
+    end
+  end
+
+  describe '#create?' do
+    it 'is true' do
+      expect(subject.create?).to eq(true)
+    end
+  end
+end

--- a/spec/requests/api/v1/organisation_type_spec.rb
+++ b/spec/requests/api/v1/organisation_type_spec.rb
@@ -13,6 +13,61 @@ describe Api::V1::OrganisationTypesController do
       }
     }
     context 'with no authentication' do
+      describe 'GET #show with ID' do
+        let(:perform_request) { get "/api/v1/organisation_types/#{requested_id}", params: params, headers: headers }
+
+        let(:organisation_type) do
+          create(:organisation_type, name: 'Local Authority')
+        end
+
+        context 'when the requested entity does not exist' do
+          let(:requested_id) { organisation_type.id + 1 }
+
+          it 'returns http not found' do
+            perform_request
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
+        context 'when the requested entity exists' do
+          let(:requested_id) { organisation_type.id }
+
+          it 'returns http success' do
+            perform_request
+            expect(response).to have_http_status(:success)
+          end
+
+          describe 'the response body' do
+            it 'is JSON' do
+              perform_request
+              expect(response.content_type).to eq('application/vnd.api+json')
+            end
+
+            describe 'the JSON body' do
+              let(:body) do
+                perform_request
+                response.body
+              end
+              let(:parsed_json) { JSON.parse(body) }
+              let(:data) { parsed_json['data'] }
+
+
+              it 'is valid ' do
+                expect{ parsed_json }.to_not raise_error
+              end
+
+              it 'has jsonapi-compliant keys' do
+                expect(data.keys).to match_array(["attributes", "id", "links", "type"])
+              end
+
+              it 'has the attributes of an OrganisationType' do
+                expect(data['attributes'].keys).to match_array(OrganisationType.new.attributes.keys)
+              end
+            end
+          end
+        end
+      end
+
       describe 'GET #index' do
         let(:perform_request) { get '/api/v1/organisation_types', params: params, headers: headers }
         it 'returns http success' do
@@ -26,14 +81,15 @@ describe Api::V1::OrganisationTypesController do
             perform_request
             response.body
           end
-          let(:parsed_json) { JSON.parse(body) }
-
           it 'is JSON' do
             perform_request
             expect(response.content_type).to eq('application/vnd.api+json')
           end
 
           describe 'the JSON body' do
+            let(:parsed_json) { JSON.parse(body) }
+            let(:data) { parsed_json['data'] }
+
             it 'is valid ' do
               expect{ parsed_json }.to_not raise_error
             end

--- a/spec/requests/api/v1/organisation_type_spec.rb
+++ b/spec/requests/api/v1/organisation_type_spec.rb
@@ -32,6 +32,17 @@ describe Api::V1::OrganisationTypesController do
         context 'when the requested entity exists' do
           let(:requested_id) { organisation_type.id }
 
+          context 'when the current user is not authorized to show the entity' do
+            before do
+              allow_any_instance_of(OrganisationTypePolicy).to receive(:show?).and_return(false)
+            end
+
+            it 'returns status forbidden' do
+              perform_request
+              expect(response).to have_http_status(:forbidden)
+            end
+          end
+
           it 'returns http success' do
             perform_request
             expect(response).to have_http_status(:success)


### PR DESCRIPTION
It's easiest to introduce an authorization framework right from the start, so that abstractions & generic elements can be identified as you go, rather than adding it retrospectively after a load of code is already written.

So this PR adds the [Pundit](https://github.com/varvet/pundit) gem, with a default policy of 'forbid everything', and an OrganisationTypePolicy of 'allow everything'. Once we have incorporated the concept of a user identity, we can revisit this.

The following screenshot is purely for the purposes of illustrating what a 'forbidden' response will look like (the actual URL used will not be forbidden if you run a genuine request):

![screen shot 2019-03-01 at 17 20 40](https://user-images.githubusercontent.com/134501/53654928-d32f9900-3c46-11e9-90ae-7aedd1274e24.png)
 