### PR TITLE
add create method + tests, for organisation_types

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -8,6 +8,8 @@ module Api
 
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+      rescue_from ActionController::ParameterMissing, with: :bad_request
+      rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity
 
       # we have no concept of user identity yet, but Pundit requires a
       # current_user method
@@ -29,14 +31,22 @@ module Api
 
       private
 
-      def respond_with(data)
+      def respond_with(data, args={})
         if request.format.json?
-          render jsonapi: data
+          render jsonapi: data, status: args[:status]
         end
       end
 
       def not_found(exception)
         render json: {error: exception}, status: :not_found
+      end
+
+      def bad_request(exception)
+        render json: {error: exception}, status: :bad_request
+      end
+
+      def unprocessable_entity(exception)
+        render json: {error: exception}, status: :unprocessable_entity
       end
 
       def user_not_authorized(exception)

--- a/app/controllers/api/v1/organisation_types_controller.rb
+++ b/app/controllers/api/v1/organisation_types_controller.rb
@@ -15,6 +15,20 @@ module Api
         authorize @organisation_type
         respond_with @organisation_type
       end
+
+      def create
+        @organisation_type = OrganisationType.create!(organisation_type_params)
+        authorize @organisation_type
+        response.headers['Location'] = url_for([:api, :v1, @organisation_type])
+
+        respond_with  @organisation_type, status: :created
+      end
+
+      private
+
+      def organisation_type_params(opts = params)
+        opts.require(:data).require(:attributes).permit(:name)
+      end
     end
   end
 end

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -1,4 +1,8 @@
 class OrganisationType < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
+
+  validates :name,  uniqueness: true,
+                    presence: true,
+                    length: {minimum: 2, maximum: 64}
 end


### PR DESCRIPTION
Allow you to create an OrganisationType by POST-ing a JSON:API-compliant packet to /api/v1/organisation_types:

![screen shot 2019-03-04 at 12 51 31](https://user-images.githubusercontent.com/134501/53734643-7f0dfa00-3e7c-11e9-9b89-fd0c41af5629.png)
