### PR TITLE
add update method for organisation_types, and tests

### DIFF
--- a/app/controllers/api/v1/organisation_types_controller.rb
+++ b/app/controllers/api/v1/organisation_types_controller.rb
@@ -24,6 +24,13 @@ module Api
         respond_with  @organisation_type, status: :created
       end
 
+      def update
+        @organisation_type = OrganisationType.friendly.find(params[:id])
+        @organisation_type.update!(organisation_type_params)
+        authorize @organisation_type
+        respond_with  @organisation_type, status: :ok
+      end
+
       private
 
       def organisation_type_params(opts = params)


### PR DESCRIPTION
Allows you to update a resource by perform a HTTP PATCH request to it's URL, passing 'data'=>{ 'attributes' => {...}} for all attributes you want to update.

![screen shot 2019-03-04 at 13 52 12](https://user-images.githubusercontent.com/134501/53737551-c13b3980-3e84-11e9-8034-ffc27b53ebac.png)
