### PR TITLE
add delete method for organisation_types

### DIFF
--- a/app/controllers/api/v1/organisation_types_controller.rb
+++ b/app/controllers/api/v1/organisation_types_controller.rb
@@ -17,8 +17,9 @@ module Api
       end
 
       def create
-        @organisation_type = OrganisationType.create!(organisation_type_params)
+        @organisation_type = OrganisationType.new(organisation_type_params)
         authorize @organisation_type
+        @organisation_type.save!
         response.headers['Location'] = url_for([:api, :v1, @organisation_type])
 
         respond_with  @organisation_type, status: :created
@@ -26,9 +27,16 @@ module Api
 
       def update
         @organisation_type = OrganisationType.friendly.find(params[:id])
-        @organisation_type.update!(organisation_type_params)
         authorize @organisation_type
+        @organisation_type.update!(organisation_type_params)
         respond_with  @organisation_type, status: :ok
+      end
+
+      def destroy
+        @organisation_type = OrganisationType.friendly.find(params[:id])
+        authorize @organisation_type
+        @organisation_type.destroy!
+        render jsonapi: nil, status: :no_content
       end
 
       private

--- a/spec/requests/api/v1/organisation_type_spec.rb
+++ b/spec/requests/api/v1/organisation_type_spec.rb
@@ -13,6 +13,43 @@ describe "API V1 OrganisationTypes", type: :request do
       }
     }
     context 'with no authentication' do
+
+      describe 'DELETE :id' do
+        let!(:organisation_type) { create(:organisation_type, name: 'existing organisation_type') }
+        let(:perform_request) do
+          delete "/api/v1/organisation_types/#{organisation_type.id}", params: params, headers: headers
+        end
+
+        context 'when the current user is not authorized to delete the entity' do
+          before do
+            allow_any_instance_of(OrganisationTypePolicy).to receive(:destroy?).and_return(false)
+          end
+
+          it 'returns status forbidden' do
+            perform_request
+            expect(response).to have_http_status(:forbidden)
+          end
+
+          it 'does not delete the entity' do
+            expect{ perform_request }.to_not change(OrganisationType, :count)
+          end
+
+        end
+
+        context 'when the current user is authorized to delete the entity' do
+          it 'deletes the entity' do
+            expect{ perform_request }.to change(OrganisationType, :count).by(-1)
+          end
+
+          describe 'the response' do
+            it 'has status 204 No Content' do
+              perform_request
+              expect(response).to have_http_status(:no_content)
+            end
+          end
+        end
+      end
+
       describe 'PATCH :id' do
         let(:organisation_type) { create(:organisation_type, name: 'existing organisation_type') }
         let(:new_name) { 'new organisation_type name' }


### PR DESCRIPTION
This PR will allow you to delete an OrganisationType by performing a HTTP DELETE request to its URL.
Responds with HTTP 204 No Content as per the [JSON:API Spec](https://jsonapi.org/format/#crud-deleting-responses-204)

![screen shot 2019-03-04 at 15 08 03](https://user-images.githubusercontent.com/134501/53741919-593e2080-3e8f-11e9-8876-49e46ae6823c.png)

