### PR TITLE
Fix incorrect type on policy_area, add explicit specs

### DIFF
--- a/app/models/serializable_policy_area.rb
+++ b/app/models/serializable_policy_area.rb
@@ -1,5 +1,5 @@
 class SerializablePolicyArea < JSONAPI::Serializable::Resource
-  type :organisation_types
+  type :policy_areas
 
   attributes :id, :slug, :name, :created_at, :updated_at
 

--- a/app/models/serializable_region.rb
+++ b/app/models/serializable_region.rb
@@ -1,5 +1,5 @@
 class SerializableRegion < JSONAPI::Serializable::Resource
-  type :region
+  type :regions
 
   attributes :id, :slug, :name, :nuts_code, :created_at, :updated_at
 

--- a/spec/requests/api/v1/shared_examples/json_api/create.rb
+++ b/spec/requests/api/v1/shared_examples/json_api/create.rb
@@ -77,6 +77,10 @@ RSpec.shared_examples 'a JSON:API-compliant create method' do |model_class|
               it 'has the attributes of the model_class' do
                 expect(data['attributes'].keys).to match_array(model_class.new.attributes.keys)
               end
+              
+              it 'has the expected type for an array of the model class' do
+                expect(data['type']).to eq(model_class.name.underscore.pluralize)
+              end
             end
           end
         end

--- a/spec/requests/api/v1/shared_examples/json_api/index.rb
+++ b/spec/requests/api/v1/shared_examples/json_api/index.rb
@@ -62,6 +62,11 @@ RSpec.shared_examples 'a JSON:API-compliant index method' do |model_class|
                   expect(element['attributes'].keys).to match_array(model_class.new.attributes.keys)
                 end
               end
+              it 'has the expected type for an array of the model class' do
+                data.each do |element|
+                  expect(element['type']).to eq(model_class.name.underscore.pluralize)
+                end
+              end
             end
           end
 

--- a/spec/requests/api/v1/shared_examples/json_api/show.rb
+++ b/spec/requests/api/v1/shared_examples/json_api/show.rb
@@ -64,6 +64,10 @@ RSpec.shared_examples 'a JSON:API-compliant show method' do |model_class|
           it 'has the attributes of the model_class' do
             expect(data['attributes'].keys).to match_array(model_class.new.attributes.keys)
           end
+
+          it 'has the expected type for an array of the model class' do
+            expect(data['type']).to eq(model_class.name.underscore.pluralize)
+          end
         end
       end
     end

--- a/spec/requests/api/v1/shared_examples/json_api/update.rb
+++ b/spec/requests/api/v1/shared_examples/json_api/update.rb
@@ -68,6 +68,10 @@ RSpec.shared_examples 'a JSON:API-compliant update method' do |model_class|
               it "has the right attributes for #{model_class}" do
                 expect(data['attributes'].keys).to match_array(model_class.new.attributes.keys)
               end
+
+              it 'has the expected type for an array of the model class' do
+                expect(data['type']).to eq(model_class.name.underscore.pluralize)
+              end
             end
           end
         end


### PR DESCRIPTION
There was a copy-and-paste error in the type declaration of SerializablePolicyArea which meant the API was returning them with a type of "organisation_types". This PR fixes this, makes :region plural for consistency & JSON:API compliance, and adds explicit RSpec test cases for the type of returned objects.