### PR TITLE
add v1 people API

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class PeopleController < Api::V1::ApiController
+      def index
+        @people = helpers.paginate(
+          Person.all
+            .order(helpers.to_activerecord_order_clause(params[:sort]))
+        )
+        authorize @people
+        respond_with @people
+      end
+
+      def show
+        @person = Person.friendly.find(params[:id])
+        authorize @person
+        respond_with @person
+      end
+
+      def create
+        @person = Person.new(person_params)
+        authorize @person
+        @person.save!
+        response.headers['Location'] = url_for([:api, :v1, @person])
+
+        respond_with  @person,  status: :created
+      end
+
+      def update
+        @person = Person.friendly.find(params[:id])
+        authorize @person
+        @person.update!(person_params)
+        respond_with  @person, status: :ok
+      end
+
+      def destroy
+        @person = Person.friendly.find(params[:id])
+        authorize @person
+        @person.destroy!
+        render jsonapi: nil, status: :no_content
+      end
+
+      private
+
+      def person_params(opts = params)
+        opts.require(:data).require(:attributes).permit(:name, :slug, :title)
+      end
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,0 +1,9 @@
+class Person < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
+  validates :name,      presence: true,
+                        uniqueness: false,
+                        length: {minimum: 2, maximum: 256}
+
+end

--- a/app/models/serializable_person.rb
+++ b/app/models/serializable_person.rb
@@ -1,0 +1,9 @@
+class SerializablePerson < JSONAPI::Serializable::Resource
+  type :people
+
+  attributes :id, :slug, :name, :title, :created_at, :updated_at
+
+  link :self do
+    @url_helpers.api_v1_people_path(@object.id)
+  end
+end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -1,0 +1,2 @@
+class PersonPolicy < OpenPolicy
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :organisations
       resources :organisation_types
+      resources :people
       resources :policy_areas
       resources :regions
       resources :role_types

--- a/db/migrate/20190311103620_create_people.rb
+++ b/db/migrate/20190311103620_create_people.rb
@@ -1,0 +1,11 @@
+class CreatePeople < ActiveRecord::Migration[5.2]
+  def change
+    create_table :people do |t|
+      t.string :name
+      t.string :slug, unique: true
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_08_144324) do
+ActiveRecord::Schema.define(version: 2019_03_11_103620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,14 @@ ActiveRecord::Schema.define(version: 2019_03_08_144324) do
     t.index ["organisation_type_id"], name: "index_organisations_on_organisation_type_id"
     t.index ["region_id", "organisation_type_id", "name"], name: "ix_orgs_region_org_type_name", unique: true
     t.index ["region_id"], name: "index_organisations_on_region_id"
+  end
+
+  create_table "people", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "policy_areas", force: :cascade do |t|

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :person do
+    name { "Joe Bloggs" }
+    title { "Mr" }
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'support/factory_bot'
+
+describe Person do
+  context 'creating a Person' do
+    context 'when the same name already exists' do
+      let!(:existing_person) { create(:person, title: 'Mr', name: 'John Smith') }
+      let(:new_person) { create(:person, title: 'Mr', name: 'John Smith') }
+
+      it 'saves with no errors' do
+        expect { new_person }.to_not raise_error
+      end
+
+      it 'makes a unique slug' do
+        expect(new_person.slug).to_not eq(existing_person.slug)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/people_spec.rb
+++ b/spec/requests/api/v1/people_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+require 'support/factory_bot'
+require 'requests/api/v1/shared_examples/json_api'
+
+describe "API V1 Persons", type: :request do
+  let(:headers) { {} }
+  let(:params) { {} }
+
+  context 'a JSON request' do
+    let(:headers) {
+      {
+        "ACCEPT" => "application/json",     # This is what Rails 4 accepts
+        "HTTP_ACCEPT" => "application/json" # This is what Rails 3 accepts
+      }
+    }
+
+    context 'with no authentication' do
+      describe 'DELETE :id' do
+        let(:model_instance) { create(:person, name: 'existing person', title: 'Ms.') }
+        let(:url) { "/api/v1/people/#{model_instance.id}" }
+        it_behaves_like 'a JSON:API-compliant delete method', Person
+
+      end
+
+      describe 'PATCH :id' do
+        let(:model_instance) { create(:person, name: 'existing person', title: 'Ms.') }
+        let(:url) { "/api/v1/people/#{model_instance.id}" }
+        let(:valid_params) do
+          {
+            data: {
+              type: 'person',
+              id: model_instance.id,
+              attributes: {
+                name: 'valid new person name',
+                title: 'Ms.'
+              }
+            }
+          }
+        end
+        let(:invalid_params) do
+          {
+            data: {
+              type: 'person',
+              id: model_instance.id,
+              attributes: {
+                name: ''
+              }
+            }
+          }
+        end
+        it_behaves_like 'a JSON:API-compliant update method', Person
+      end
+
+
+      describe 'POST' do
+        let(:url) { "/api/v1/people" }
+        let(:valid_params) do
+          {
+            data: {
+              type: 'person',
+              attributes: {
+                name: 'new person',
+                title: 'Ms.'
+              }
+            }
+          }
+        end
+        let(:invalid_params) do
+          {
+            data: {
+              type: 'person',
+              attributes: {
+                name: ''
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'a JSON:API-compliant create method', Person
+      end
+
+      describe 'GET #show with ID' do
+        let(:url) { "/api/v1/people/#{model_instance.id}" }
+        let(:model_instance) do
+          create(:person, name: 'Jane Doe', title: 'Ms.')
+        end
+
+        it_behaves_like 'a JSON:API-compliant show method', Person
+      end
+
+      describe 'GET #index' do
+        let(:url) { '/api/v1/people' }
+        let(:model_instance_1) { create(:person, name: 'Jane Doe', title: 'Ms.') }
+        let(:model_instance_2) { create(:person, name: 'Abby Gail', title: 'Ms.') }
+        let(:sort_attribute) { 'name' }
+
+        it_behaves_like 'a JSON:API-compliant index method', Person
+      end
+    end
+  end
+end


### PR DESCRIPTION
A Person has a title and name. As discussed, this is purely the quickest possible route to getting the alpha in front of people - we can refactor to a more generic schema later.

No included roles or contacts yet (they'll be coming in the next PRs!)

Note that it's perfectly possible to have several people with the same name. It will automatically create a unique suffix to the slug if that happens (see screenshot below)

![Screen Shot 2019-03-11 at 10 59 10](https://user-images.githubusercontent.com/134501/54119401-22b35900-43ed-11e9-97ac-60c173a2aed1.png)
