### PR TITLE
add simple text search to people

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem 'kaminari'
 
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
+# Full-text search wrapper 
+gem 'pg_search'
+
 # Use Pry for the console - solves some issues with arrow keys on Mac OSX
 gem 'pry-rails'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    pg_search (2.1.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -217,6 +220,7 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pg_search
   pry-rails
   puma (~> 3.11)
   pundit

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -58,7 +58,6 @@ module Api
 
         render json: {error: exception}, status: :forbidden
       end
-
     end
   end
 end

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -2,10 +2,10 @@ module Api
   module V1
     class PeopleController < Api::V1::ApiController
       def index
-        @people = helpers.paginate(
-          Person.all
-            .order(helpers.to_activerecord_order_clause(params[:sort]))
-        )
+        people_scope = Person.all
+          .order(helpers.to_activerecord_order_clause(params[:sort]))
+        people_scope = helpers.add_filter_if_given(people_scope)
+        @people = helpers.paginate(people_scope)
         authorize @people
         respond_with @people, include: [roles: [:organisation, :role_type, :region]]
       end

--- a/app/helpers/api/v1/api_helper.rb
+++ b/app/helpers/api/v1/api_helper.rb
@@ -102,4 +102,10 @@ module Api::V1::ApiHelper
     ) unless collection.last_page?
   end
 
+  def add_filter_if_given(given_scope, filter=params[:filter])
+    if filter
+      given_scope = given_scope.search(filter[:search]) if filter[:search].present?
+    end
+    given_scope
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,9 +3,28 @@ class Person < ApplicationRecord
   friendly_id :name, use: :slugged
 
   has_many :roles
-  
+  has_many :organisations, through: :roles
+
   validates :name,      presence: true,
                         uniqueness: false,
                         length: {minimum: 2, maximum: 256}
 
+  include PgSearch
+  pg_search_scope :search,
+                  against: [ :name, :title ],
+                  associated_against: {
+                    organisations: [:name],
+                    roles: [:title]
+                  },
+                  using: {
+                    tsearch: { prefix: true }
+                  }
+
+  def role_titles
+    roles.map(&:title)
+  end
+
+  def organisation_names
+    roles.map{|role| role.organisation.name}
+  end
 end

--- a/spec/requests/api/v1/people_spec.rb
+++ b/spec/requests/api/v1/people_spec.rb
@@ -51,7 +51,6 @@ describe "API V1 Persons", type: :request do
         it_behaves_like 'a JSON:API-compliant update method', Person
       end
 
-
       describe 'POST' do
         let(:url) { "/api/v1/people" }
         let(:valid_params) do
@@ -87,7 +86,7 @@ describe "API V1 Persons", type: :request do
 
         it_behaves_like 'a JSON:API-compliant show method', Person
 
-        context 'when the Person has roles' do
+        context 'when a Person has roles' do
           let(:region_id){ nil }
           let!(:role) { create(:role, person: model_instance, region_id: region_id) }
           let(:included_object_types_and_ids) do
@@ -126,6 +125,39 @@ describe "API V1 Persons", type: :request do
         let(:sort_attribute) { 'name' }
 
         it_behaves_like 'a JSON:API-compliant index method', Person
+
+        context 'given a search filter' do
+          before do
+            model_instance_1
+            model_instance_2
+          end
+
+          let(:params) { { filter: {search: search_string} } }
+          before do
+            get url, params: params, headers: headers
+          end
+          let(:results) { JSON.parse(response.body)['data'] }
+
+          context 'containing text that matches a surname' do
+            let(:search_string) { 'Do' }
+
+            it 'brings back records that match the given text' do
+              results.each do |result|
+                expect(result['attributes']['name']).to include(search_string)
+              end
+            end
+          end
+
+          context 'containing text that matches a first name' do
+            let(:search_string) { 'Abb' }
+
+            it 'brings back records that match the given text' do
+              results.each do |result|
+                expect(result['attributes']['name']).to include(search_string)
+              end
+            end
+          end
+        end
 
         context 'when the Person has roles' do
           let(:region_id){ nil }


### PR DESCRIPTION
Add the query param "filter[search]" to /api/v1/people to perform a search. It indexes their name, title, and the names/titles of any roles and organisations they have.

NOTE: to get this done as quickly as possible, it uses Postgres' "prefix" search method - you can search for multiple words at once, but it will only bring back matches for words which _start_ with what you entered.

So, if you have a person called Joe Bloggs, CEO of Acme Construction, you can bring them back with searches for:
"Blog"
"Jo Acme"
"Jo CEO construct"

but not "oggs", or "cme". 

More sophisticated wildcard-searching would have required installation of PostgreSQL extensions, which can get fiddly on Heroku / RDS.

![Screen Shot 2019-03-11 at 16 19 38](https://user-images.githubusercontent.com/134501/54140457-90767980-441b-11e9-8ad4-4519f264a5fb.png)
