### PR TITLE
allow create/update of entire engagement policy_areas collection

### DIFF
--- a/app/models/engagement.rb
+++ b/app/models/engagement.rb
@@ -2,6 +2,9 @@ class Engagement < ApplicationRecord
   belongs_to :stakeholder, class_name: 'Person'
   belongs_to :recorded_by, class_name: 'Person'
 
+  has_many :engagement_policy_areas
+  has_many :policy_areas, through: :engagement_policy_areas
+
 
   def slug
     id


### PR DESCRIPTION
 when creating/updating an engagement as per [the JSON:API spec](https://jsonapi.org/format/#crud-updating-resource-relationships)

<img width="1066" alt="Screen Shot 2019-03-13 at 16 09 16" src="https://user-images.githubusercontent.com/134501/54295139-60a9ac00-45aa-11e9-85cb-24b34ddc26be.png">
